### PR TITLE
[MINOR] Update README with TRMNL Recipe Connections count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # New York Times Best Sellers for TRMNL
 
-[![Build and Deploy](https://github.com/stephenyeargin/trmnl-nyt-best-sellers/actions/workflows/build.yml/badge.svg)](https://github.com/stephenyeargin/trmnl-nyt-best-sellers/actions/workflows/build.yml)
+[![Build and Deploy](https://github.com/stephenyeargin/trmnl-nyt-best-sellers/actions/workflows/build.yml/badge.svg)](https://github.com/stephenyeargin/trmnl-nyt-best-sellers/actions/workflows/build.yml) [![TRMNL Recipe Connections](https://trmnl-badges.gohk.xyz/badge/connections?recipe=121924)](https://trmnl.com/recipes/121924)
 
 ![promo](assets/promo.png)
 


### PR DESCRIPTION
👋🏽 I see that you have multiple open-source TRMNL plugins.

I made this recipe install count badge builder that you can use for fun - https://hossain-khan.github.io/trmnl-badges/

If this is not something you want, feel free to close the PR. Just wanted to share the [existence](https://discord.com/channels/1281055965508141100/1284986484767723611/1472565221594894569).